### PR TITLE
return only rest of the wallets path if it's partially equal to Dir.pwd

### DIFF
--- a/lib/zold/wallets.rb
+++ b/lib/zold/wallets.rb
@@ -34,16 +34,17 @@ module Zold
 
     # Returns wallets directory path
     def to_s
-      dir = Dir.pwd[1..-1].split('/')
+      dir = Dir.pwd.sub(path_start, '').split('/')
       diff = false
-      pwd = path[1..-1].split('/').each_with_index.with_object([]) do |(fld, idx), obj|
+      dir_path = path.sub(path_start, '').split('/')
+      pwd = dir_path.each_with_index.with_object([]) do |(fld, idx), obj|
         break if idx.zero? && fld != dir[idx]
         next if fld == dir[idx]
         obj << fld
         diff ||= true
       end
       return path if pwd.nil? || pwd.empty?
-      pwd[0] == '/' ? pwd.join('/') : ('./' << pwd.join('/'))
+      pwd[0] == path_start ? pwd.join('/') : ('./' << pwd.join('/'))
     end
 
     def path
@@ -64,6 +65,16 @@ module Zold
 
     def find(id)
       Zold::Wallet.new(File.join(path, id.to_s))
+    end
+
+    private
+
+    def path_start
+      windows? ? Dir.pwd[0..1] : '/'
+    end
+
+    def windows?
+      (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
     end
   end
 end

--- a/lib/zold/wallets.rb
+++ b/lib/zold/wallets.rb
@@ -32,11 +32,18 @@ module Zold
       @dir = dir
     end
 
-    # @todo #70:30min Let's make it smarter. Instead of returning
-    #  the full path let's substract the prefix from it if it's equal
-    #  to the current directory in Dir.pwd.
+    # Returns wallets directory path
     def to_s
-      path
+      dir = Dir.pwd[1..-1].split('/')
+      diff = false
+      pwd = path[1..-1].split('/').each_with_index.with_object([]) do |(fld, idx), obj|
+        break if idx.zero? && fld != dir[idx]
+        next if fld == dir[idx]
+        obj << fld
+        diff ||= true
+      end
+      return path if pwd.nil? || pwd.empty?
+      pwd[0] == '/' ? pwd.join('/') : ('./' << pwd.join('/'))
     end
 
     def path

--- a/test/test_wallets.rb
+++ b/test/test_wallets.rb
@@ -50,4 +50,11 @@ class TestWallets < Minitest::Test
       assert_equal(1, wallets.all.count)
     end
   end
+
+  def test_return_full_directory_path_if_different_from_current_directory
+    FakeHome.new.run do |home|
+      assert Dir.pwd != home.wallets.to_s
+      assert_equal(home.dir, home.wallets.to_s)
+    end
+  end
 end


### PR DESCRIPTION
## Issue

https://github.com/zold-io/zold/issues/78

## Changelog

- return only rest of the wallets path if it's partially equal to Dir.pwd
- return full path in other cases