### PR TITLE
#168 Fix incorrect commands to run zold node

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ In order to do that just run (with your own wallet ID, of course,
 and your own public IP address instead of `4.4.4.4`):
 
 ```bash
-$ zold --trace --verbose --invoice=5f96e731e48ae21f --host=4.4.4.4
+$ zold node --trace --verbose --invoice=5f96e731e48ae21f --host=4.4.4.4
 ```
 
 Then, open the page `4.4.4.4:4096` in your browser
@@ -102,7 +102,7 @@ Next, hit <kbd>Ctrl</kbd>+<kbd>c</kbd> and run it again, but instead
 of `zold` say `zold-nohup` and add an ampersand (`&`) at the end:
 
 ```bash
-$ zold-nohup --trace --verbose --invoice=5f96e731e48ae21f --host=4.4.4.4 &
+$ zold-nohup node --trace --verbose --invoice=5f96e731e48ae21f --host=4.4.4.4 &
 ```
 
 Now you can close console, it will work in the background, saving the


### PR DESCRIPTION
Attempting to run what's given in the readme file currently results in a RuntimeError:
```
$ zold --trace --verbose --invoice=ceda7c5ff887de31 --host=46.101.148.53
ERROR: A command required, try --help (RuntimeError)
/var/lib/gems/2.3.0/gems/zold-0.10.21/bin/zold:112:in `<top (required)>'
/usr/local/bin/zold:23:in `load'
/usr/local/bin/zold:23:in `<main>'
```