### PR TITLE
Fix #113

### DIFF
--- a/lib/zold/score.rb
+++ b/lib/zold/score.rb
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-require 'digest'
+require 'openssl'
 require 'time'
 require_relative 'remotes'
 
@@ -101,7 +101,7 @@ module Zold
     def hash
       raise 'Score has zero value, there is no hash' if @suffixes.empty?
       @suffixes.reduce(prefix) do |pfx, suffix|
-        Digest::SHA256.hexdigest(pfx + ' ' + suffix)[0, 64]
+        OpenSSL::Digest::SHA256.new("#{pfx} #{suffix}").hexdigest[0, 64]
       end
     end
 


### PR DESCRIPTION
The stdlib Digest is not thread-safe. Replacing with OpenSSL::Digest.

(_Alternatively there's a [patch for Digest](https://github.com/ruby/digest/commit/afb3fb97b29b1597b74b1a681dfcc4908aaa9c34), but I think this solution is good._)

**Next steps:** Digest is used in other places. I fixed only what was subject of the bug, but a new issue should be created address the other occurrences.

**Statistics:** I spent 31 minutes on this issue.