### PR TITLE
Fix  #287 - wallet amount overflow in Wallet and Patch

### DIFF
--- a/lib/zold/wallet.rb
+++ b/lib/zold/wallet.rb
@@ -123,6 +123,7 @@ module Zold
     end
 
     def add(txn)
+      raise "Wallet amount will exceed MAX if applied #{txn}" if (balance.to_i + txn.amount.to_i).abs > Amount::MAX
       raise 'The txn has to be of type Txn' unless txn.is_a?(Txn)
       dup = txns.find { |t| t.bnf == txn.bnf && t.id == txn.id }
       raise "The transaction with the same ID and BNF already exists: #{dup}" unless dup.nil?

--- a/test/test_wallet.rb
+++ b/test/test_wallet.rb
@@ -155,4 +155,19 @@ class TestWallet < Minitest::Test
       )
     end
   end
+
+  def test_not_allow_amount_exceed_max
+    coins = 2**63 - 1
+    FakeHome.new.run do |home|
+      wallet = home.create_wallet
+      time = Time.now
+      sign = [1, -1].sample
+      wallet.add(Zold::Txn.new(1, time, Zold::Amount.new(coins: 2 * sign), 'NOPREFIX', Zold::Id.new, '-'))
+      txn = Zold::Txn.new(1, time, Zold::Amount.new(coins: coins * sign), 'NOPREFIX', Zold::Id.new, '-')
+      error = assert_raises RuntimeError do
+        wallet.add(txn)
+      end
+      assert !error.message.index("Wallet amount will exceed MAX if applied #{txn}").nil?
+    end
+  end
 end


### PR DESCRIPTION
This is fix for [#287](https://github.com/zold-io/zold/issues/287). Patch#join part seems to be right and staightforward although I omitted test facing a problem of creating wallet fixture. Created [#325](https://github.com/zold-io/zold/issues/325) for that matter.