### PR TITLE
Fix #79: notify about taxes after each PAY

### DIFF
--- a/lib/zold/commands/pay.rb
+++ b/lib/zold/commands/pay.rb
@@ -107,7 +107,7 @@ Available options:"
       txn
     end
 
-    # TODO: add tests, extract to a module(?).
+    # @todo #79:40min Add tests, extract to a module(?).
     def notify_of_tax_debt(wallet)
       tax = Tax.new(wallet)
       message = "The tax debt of #{wallet} is #{tax.debt}"

--- a/lib/zold/commands/pay.rb
+++ b/lib/zold/commands/pay.rb
@@ -107,7 +107,9 @@ Available options:"
       txn
     end
 
-    # @todo #79:40min Add tests, extract to a module(?).
+    # @todo #79:40min Extract message cretion into a separate method for easier
+    #  testing. Add tests for when in debt and not. Extract to a
+    #  module, possibly Notify.
     def notify_of_tax_debt(wallet)
       tax = Tax.new(wallet)
       message = "The tax debt of #{wallet} is #{tax.debt}"

--- a/lib/zold/commands/pay.rb
+++ b/lib/zold/commands/pay.rb
@@ -103,7 +103,16 @@ Available options:"
       @log.debug("#{amount} sent from #{from} to #{txn.bnf}: #{details}")
       @log.debug("Don't forget to do 'zold push #{from}'")
       @log.info(txn.id)
+      notify_of_tax_debt(from)
       txn
+    end
+
+    # TODO: add tests, extract to a module(?).
+    def notify_of_tax_debt(wallet)
+      tax = Tax.new(wallet)
+      message = "The tax debt of #{wallet} is #{tax.debt}"
+      message += ' (still acceptable)' unless tax.in_debt?
+      @log.info(message)
     end
   end
 end

--- a/test/commands/test_pay.rb
+++ b/test/commands/test_pay.rb
@@ -88,20 +88,21 @@ class TestPay < Minitest::Test
       source = home.create_wallet
       target = home.create_wallet
       amount = Zold::Amount.new(zld: 14.95)
-      class << test_log
+      accumulating_log = test_log.dup
+      class << accumulating_log
         attr_accessor :info_messages
 
         def info(message)
           (@info_messages ||= []) << message
         end
       end
-      Zold::Pay.new(wallets: home.wallets, remotes: home.remotes, log: test_log).run(
+      Zold::Pay.new(wallets: home.wallets, remotes: home.remotes, log: accumulating_log).run(
         [
           'pay', '--force', '--private-key=fixtures/id_rsa',
           source.id.to_s, target.id.to_s, amount.to_zld, 'For the car'
         ]
       )
-      assert_equal test_log.info_messages.grep(/^The tax debt/).size, 1,
+      assert_equal accumulating_log.info_messages.grep(/^The tax debt/).size, 1,
         'No info_messages notified user of tax debt'
     end
   end

--- a/test/commands/test_pay.rb
+++ b/test/commands/test_pay.rb
@@ -88,7 +88,6 @@ class TestPay < Minitest::Test
       source = home.create_wallet
       target = home.create_wallet
       amount = Zold::Amount.new(zld: 14.95)
-
       class << test_log
         attr_accessor :info_messages
 
@@ -96,14 +95,12 @@ class TestPay < Minitest::Test
           (@info_messages ||= []) << message
         end
       end
-
       Zold::Pay.new(wallets: home.wallets, remotes: home.remotes, log: test_log).run(
         [
           'pay', '--force', '--private-key=fixtures/id_rsa',
           source.id.to_s, target.id.to_s, amount.to_zld, 'For the car'
         ]
       )
-
       assert_equal test_log.info_messages.grep(/^The tax debt/).size, 1,
         'No info_messages notified user of tax debt'
     end

--- a/test/commands/test_pay.rb
+++ b/test/commands/test_pay.rb
@@ -82,4 +82,30 @@ class TestPay < Minitest::Test
       assert_equal(Zold::Amount::ZERO, source.balance)
     end
   end
+
+  def test_notifies_about_tax_status
+    FakeHome.new.run do |home|
+      source = home.create_wallet
+      target = home.create_wallet
+      amount = Zold::Amount.new(zld: 14.95)
+
+      class << test_log
+        attr_accessor :info_messages
+
+        def info(message)
+          (@info_messages ||= []) << message
+        end
+      end
+
+      Zold::Pay.new(wallets: home.wallets, remotes: home.remotes, log: test_log).run(
+        [
+          'pay', '--force', '--private-key=fixtures/id_rsa',
+          source.id.to_s, target.id.to_s, amount.to_zld, 'For the car'
+        ]
+      )
+
+      assert_equal test_log.info_messages.grep(/^The tax debt/).size, 1,
+        'No info_messages notified user of tax debt'
+    end
+  end
 end


### PR DESCRIPTION
I would have liked to test all info output, but the wallet ids are different every time.