### PR TITLE
AtomicFile#write corrupts data when multiple threads call it

### DIFF
--- a/lib/zold/atomic_file.rb
+++ b/lib/zold/atomic_file.rb
@@ -28,20 +28,21 @@ module Zold
     def initialize(file)
       raise 'File can\'t be nil' if file.nil?
       @file = file
+      @mutex = Mutex.new
     end
 
     def read
-      File.open(@file, 'rb') do |f|
-        f.flock(File::LOCK_EX)
-        f.read
+      @mutex.synchronize do
+        File.open(@file, 'rb', &:read)
       end
     end
 
     def write(content)
       raise 'Content can\'t be nil' if content.nil?
-      File.open(@file, 'wb') do |f|
-        f.flock(File::LOCK_EX)
-        f.write(content)
+      @mutex.synchronize do
+        File.open(@file, 'wb') do |f|
+          f.write(content)
+        end
       end
     end
   end

--- a/test/test_atomic_file.rb
+++ b/test/test_atomic_file.rb
@@ -42,12 +42,7 @@ class TestAtomicFile < Minitest::Test
     end
   end
 
-  # @todo #262:30min This test is skipped because it doesn't work. I can't
-  #  understand why. It seems that File.open() creates an empty file first
-  #  which is then being read by File.read() in another thread. Let's find
-  #  out and make AtomicFile truly thread-safe.
   def test_writes_from_many_threads
-    skip
     Dir.mktmpdir 'test' do |dir|
       file = Zold::AtomicFile.new(File.join(dir, 'a.txt'))
       threads = 10


### PR DESCRIPTION
https://github.com/zold-io/zold/issues/264 `AtomicFile#write` should be thread safe and not corrupt data that ends up in the file. `#synchronize` is the way to do it.