### PR TITLE
Issue #298: if remote is missing avoid throwing an exception

### DIFF
--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -165,7 +165,13 @@ module Zold
     def load
       @mutex.synchronize do
         if File.exist?(@cache)
-          AtomicFile.new(@cache).read.split(/\n/).map { |t| Score.parse(t) }
+          AtomicFile.new(@cache).read.split(/\n/).map { |t|
+            begin
+              Score.parse(t)
+            rescue StandardError => e
+              @log.error(e.message)
+            end
+          }
         else
           []
         end

--- a/lib/zold/remotes.rb
+++ b/lib/zold/remotes.rb
@@ -187,6 +187,11 @@ module Zold
         rescue StandardError => e
           error(r[:host], r[:port])
           errors = errors(r[:host], r[:port])
+          non_fatal_errors = check_for_non_fatal_errors(r[:host], r[:port])
+          non_fatal_errors.each do |error|
+            log.info("#{Rainbow("#{r[:host]}:#{r[:port]}").red}: #{error} \
+in #{(Time.now - start).round}s;")
+          end
           log.info("#{Rainbow("#{r[:host]}:#{r[:port]}").red}: #{e.message} \
 in #{(Time.now - start).round}s; errors=#{errors}")
           log.debug(Backtrace.new(e).to_s)
@@ -195,22 +200,28 @@ in #{(Time.now - start).round}s; errors=#{errors}")
       end
     end
 
-    def errors(host, port = Remotes::PORT)
+    def check_for_non_fatal_errors(host, port = Remotes::PORT)
+      non_fatal_errors = []
+      non_fatal_errors.push("#{host}:#{port} is absent among #{load.count} remotes") unless exists?(host, port)
+      non_fatal_errors
+    end
+
+    def check_for_fatal_errors(host, port = Remotes::PORT)
       raise 'Host can\'t be nil' if host.nil?
       raise 'Port can\'t be nil' if port.nil?
       raise 'Port has to be of type Integer' unless port.is_a?(Integer)
+    end
+
+    def errors(host, port = Remotes::PORT)
+      check_for_fatal_errors(host, port)
       list = load
-      raise "#{host}:#{port} is absent among #{list.count} remotes" unless exists?(host, port)
-      list.find { |r| r[:host] == host.downcase && r[:port] == port }[:errors]
+      list.find { |r| r[:host] == host.downcase && r[:port] == port }[:errors] unless exists?(host, port) else 0
     end
 
     def error(host, port = Remotes::PORT)
-      raise 'Host can\'t be nil' if host.nil?
-      raise 'Port can\'t be nil' if port.nil?
-      raise 'Port has to be of type Integer' unless port.is_a?(Integer)
+      check_for_fatal_errors(host, port)
       list = load
-      raise "#{host}:#{port} is absent among #{list.count} remotes" unless exists?(host, port)
-      list.find { |r| r[:host] == host.downcase && r[:port] == port }[:errors] += 1
+      list.find { |r| r[:host] == host.downcase && r[:port] == port }[:errors] += 1 unless exists?(host, port)
       save(list)
     end
 

--- a/test/test_remotes.rb
+++ b/test/test_remotes.rb
@@ -169,4 +169,19 @@ class TestRemotes < Minitest::Test
       assert_equal(0, remotes.all.reject { |r| r[:host] == host }.size)
     end
   end
+
+  def test_unreachable_remote
+    Dir.mktmpdir 'test' do |dir|
+      file = File.join(dir, 'remotes')
+      FileUtils.touch(file)
+      remotes = Zold::Remotes.new(file)
+      remotes.add('127.0.0.1')
+      log = TestLogger.new
+      remotes.stub :exists?, false do
+        remotes.iterate(log) {
+          assert(log.msg.include?('127.0.0.1:4096 is absent among 1 remotes in 0s;'))
+        }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now when a remote in missing for a valid reason (ex. unreachable at the moment), no exception is thrown - just logged. Added steps to test it and checked that no previous test is broken