### PR TITLE
Issue #297 implemented: when file contains garbage the line is ignored

### DIFF
--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -48,7 +48,7 @@ module Zold
     end
 
     def best
-      load
+      load.compact
     end
 
     def to_text
@@ -165,9 +165,7 @@ module Zold
     def load
       @mutex.synchronize do
         if File.exist?(@cache)
-          AtomicFile.new(@cache).read.split(/\n/).map do |t|
-            parse_score_line(t)
-          end
+          AtomicFile.new(@cache).read.split(/\n/).map { |t| parse_score_line(t) }
         else
           []
         end
@@ -178,6 +176,7 @@ module Zold
       Score.parse(line)
     rescue StandardError => e
       @log.error(e.message)
+      nil
     end
   end
 end

--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -165,7 +165,7 @@ module Zold
     def load
       @mutex.synchronize do
         if File.exist?(@cache)
-          AtomicFile.new(@cache).read.split(/\n/).map { |t| parse_score_line(t) }
+          AtomicFile.new(@cache).read.split(/\n/).map { |t| parse_score_line(t)[0] }
         else
           []
         end
@@ -173,10 +173,11 @@ module Zold
     end
 
     def parse_score_line(line)
-      Score.parse(line)
+      score = []
+      score << Score.parse(line)
     rescue StandardError => e
       @log.error(e.message)
-      nil
+      score
     end
   end
 end

--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -165,7 +165,13 @@ module Zold
     def load
       @mutex.synchronize do
         if File.exist?(@cache)
-          AtomicFile.new(@cache).read.split(/\n/).map { |t| Score.parse(t) }
+          AtomicFile.new(@cache).read.split(/\n/).map { |t|
+            begin
+              Score.parse(t)
+            rescue StandardError => e
+              @log.error(e.message)
+            end
+          }
         else
           []
         end

--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -177,7 +177,7 @@ module Zold
     def parse_score_line(line)
       Score.parse(line)
     rescue StandardError => e
-      @log.error(e.message)
+      @log.error(Backtrace.new(e).to_s)
       Score::ZERO
     end
   end

--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -48,7 +48,7 @@ module Zold
     end
 
     def best
-      load.compact
+      load
     end
 
     def to_text
@@ -165,7 +165,9 @@ module Zold
     def load
       @mutex.synchronize do
         if File.exist?(@cache)
-          AtomicFile.new(@cache).read.split(/\n/).map { |t| parse_score_line(t)[0] }
+          AtomicFile.new(@cache).read.split(/\n/)
+            .map { |t| parse_score_line(t) }
+            .reject(&:zero?)
         else
           []
         end
@@ -173,11 +175,10 @@ module Zold
     end
 
     def parse_score_line(line)
-      score = []
-      score << Score.parse(line)
+      Score.parse(line)
     rescue StandardError => e
       @log.error(e.message)
-      score
+      Score::ZERO
     end
   end
 end

--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -166,16 +166,18 @@ module Zold
       @mutex.synchronize do
         if File.exist?(@cache)
           AtomicFile.new(@cache).read.split(/\n/).map do |t|
-            begin
-              Score.parse(t)
-            rescue StandardError => e
-              @log.error(e.message)
-            end
+            parse_score_line(t)
           end
         else
           []
         end
       end
+    end
+
+    def parse_score_line(line)
+      Score.parse(line)
+    rescue StandardError => e
+      @log.error(e.message)
     end
   end
 end

--- a/lib/zold/node/farm.rb
+++ b/lib/zold/node/farm.rb
@@ -165,13 +165,13 @@ module Zold
     def load
       @mutex.synchronize do
         if File.exist?(@cache)
-          AtomicFile.new(@cache).read.split(/\n/).map { |t|
+          AtomicFile.new(@cache).read.split(/\n/).map do |t|
             begin
               Score.parse(t)
             rescue StandardError => e
               @log.error(e.message)
             end
-          }
+          end
         else
           []
         end

--- a/lib/zold/score.rb
+++ b/lib/zold/score.rb
@@ -191,5 +191,9 @@ module Zold
     def value
       @suffixes.length
     end
+
+    def zero?
+      equal?(Score::ZERO)
+    end
   end
 end

--- a/test/node/test_farm.rb
+++ b/test/node/test_farm.rb
@@ -26,7 +26,7 @@ require_relative '../../lib/zold/log'
 require_relative '../../lib/zold/node/farm'
 
 class FarmTest < Minitest::Test
-  class TestLogger
+  class SaveLastMessageLogger
     attr_reader :msg
     def error(msg)
       @msg = msg
@@ -118,20 +118,20 @@ class FarmTest < Minitest::Test
   end
 
   def test_garbage_farm_file
-    log = TestLogger.new
+    log = SaveLastMessageLogger.new
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'corrupted_farm')
       [
         "0/6: 2018-06-26ABCT00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4\n",
         "some garbage\n"
-      ].each do |t|
-        File.write(file, t)
+      ].each do |score_garbage_line|
+        File.write(file, score_garbage_line)
         score = Zold::Score.new(
           Time.parse('2017-07-19T21:24:51Z'),
           'some-host', 9999, 'NOPREFIX@ffffffffffffffff', %w[13f7f01 b2b32b 4ade7e],
           strength: 6
         )
-        File.write(file, score.to_s, mode: 'a')
+        File.write(file, score_garbage_line + score.to_s)
         farm = Zold::Farm.new('NOPREFIX@ffffffffffffffff', file, log: log)
         assert_equal(1, farm.best.count)
         assert(log.msg.start_with?('Invalid score'))

--- a/test/node/test_farm.rb
+++ b/test/node/test_farm.rb
@@ -136,7 +136,7 @@ class FarmTest < Minitest::Test
         end
         farm = Zold::Farm.new('NOPREFIX@ffffffffffffffff', file, log: log)
         assert_equal(1, farm.best.count)
-        assert(log.msg.start_with?('Invalid score'))
+        assert(log.msg.include?('Invalid score'))
       end
     end
   end

--- a/test/node/test_farm.rb
+++ b/test/node/test_farm.rb
@@ -125,7 +125,6 @@ class FarmTest < Minitest::Test
         "0/6: 2018-06-26ABCT00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4\n",
         "some garbage\n"
       ].each do |score_garbage_line|
-        File.write(file, score_garbage_line)
         score = Zold::Score.new(
           Time.parse('2017-07-19T21:24:51Z'),
           'some-host', 9999, 'NOPREFIX@ffffffffffffffff', %w[13f7f01 b2b32b 4ade7e],

--- a/test/node/test_farm.rb
+++ b/test/node/test_farm.rb
@@ -122,15 +122,18 @@ class FarmTest < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'corrupted_farm')
       [
-        "0/6: 2018-06-26ABCT00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4\n",
-        "some garbage\n"
+        '0/6: 2018-06-26ABCT00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4',
+        'some garbage'
       ].each do |score_garbage_line|
-        score = Zold::Score.new(
+        valid_score = Zold::Score.new(
           Time.parse('2017-07-19T21:24:51Z'),
           'some-host', 9999, 'NOPREFIX@ffffffffffffffff', %w[13f7f01 b2b32b 4ade7e],
           strength: 6
         )
-        File.write(file, score_garbage_line + score.to_s)
+        File.open(file, 'w') do |f|
+          f.puts(score_garbage_line)
+          f.puts(valid_score)
+        end
         farm = Zold::Farm.new('NOPREFIX@ffffffffffffffff', file, log: log)
         assert_equal(1, farm.best.count)
         assert(log.msg.start_with?('Invalid score'))

--- a/test/node/test_farm.rb
+++ b/test/node/test_farm.rb
@@ -122,7 +122,8 @@ class FarmTest < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'corrupted_farm')
       [
-        '0/6: 2018-06-26T00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4  15e0cb 6be8b0 4849a8 305ae7d 9c30f4 e6d1e3 3b62ed 1281eb4 6b9173 449ef5',
+        '0/6: 2018-06-26T00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4 \
+         15e0cb 6be8b0 4849a8 305ae7d 9c30f4 e6d1e3 3b62ed 1281eb4 6b9173 449ef5',
         'some garbage',
         '',
         "\n\n\n\n"

--- a/test/node/test_farm.rb
+++ b/test/node/test_farm.rb
@@ -122,11 +122,8 @@ class FarmTest < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'corrupted_farm')
       [
-        '0/6: 2018-06-26T00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4 \
-         15e0cb 6be8b0 4849a8 305ae7d 9c30f4 e6d1e3 3b62ed 1281eb4 6b9173 449ef5',
-        'some garbage',
-        '',
-        "\n\n\n\n"
+        "0/6: 2018-06-26ABCT00:32:43Z 178.128.165.12 4096 MIRhypo1@c13620484b46caa4\n",
+        "some garbage\n"
       ].each do |t|
         File.write(file, t)
         score = Zold::Score.new(
@@ -136,7 +133,7 @@ class FarmTest < Minitest::Test
         )
         File.write(file, score.to_s, mode: 'a')
         farm = Zold::Farm.new('NOPREFIX@ffffffffffffffff', file, log: log)
-        assert(1, farm.best.count)
+        assert_equal(1, farm.best.count)
         assert(log.msg.start_with?('Invalid score'))
       end
     end


### PR DESCRIPTION
Issue #297 When a line of the farm file contains garbage, now it gets ignored and a message is written to the log.