### PR TITLE
Add --quiet option to rake test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,7 @@ task default: %i[clean test features rubocop xcop copyright]
 require 'rake/testtask'
 desc 'Run all unit tests'
 Rake::TestTask.new(:test) do |test|
+  ENV['TEST_QUIET_LOG'] = 'true' if ARGV.include?('--quiet')
   Rake::Cleaner.cleanup_files(['coverage'])
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -37,8 +37,11 @@ module Minitest
   class Test
     def test_log
       require_relative '../lib/zold/log'
-      # @test_log = Zold::Log::Quiet.new
-      @test_log ||= Zold::Log::Verbose.new
+      @test_log ||= if ENV['TEST_QUIET_LOG'] && ENV['TEST_QUIET_LOG'] != 'false'
+                      Zold::Log::Quiet.new
+                    else
+                      Zold::Log::Verbose.new
+                    end
     end
   end
 end


### PR DESCRIPTION
Now it is possible to suppress verbose logs for `rake` / `rake test`, using the `-- quiet` option. 
E.g. `rake --quiet`

refers to: #307 