### PR TITLE
Add tests for the alias command #322

### DIFF
--- a/bin/zold
+++ b/bin/zold
@@ -187,7 +187,7 @@ Available options:"
     Zold::Push.new(wallets: wallets, remotes: remotes, log: log).run(args)
   when 'alias'
     require_relative '../lib/zold/commands/alias'
-    Zold::Alias.new(wallets: wallets, remotes: remotes, log: log).run(args)
+    Zold::Alias.new(wallets: wallets, log: log).run(args)
   when 'score'
     require_relative '../lib/zold/commands/calculate'
     Zold::Calculate.new(log: log).run(args)

--- a/lib/zold/commands/alias.rb
+++ b/lib/zold/commands/alias.rb
@@ -6,9 +6,8 @@ require_relative '../log'
 module Zold
   # Command to set an alias for wallet ID
   class Alias
-    def initialize(wallets:, remotes:, log: Log::Quiet.new)
+    def initialize(wallets:, log: Log::Quiet.new)
       @wallets = wallets
-      @remotes = remotes
       @log = log
     end
 

--- a/test/commands/test_alias.rb
+++ b/test/commands/test_alias.rb
@@ -5,6 +5,8 @@ require_relative '../../lib/zold/commands/alias'
 
 class TestAlias < Minitest::Test
   # alias set <wallet> <alias>
+  # @todo #322:30min Implement the set command and unskip this test.
+  #  The syntax is already documented in the alias command in the help.
   def test_set_writes_alias_to_the_alias_file
     skip
     FakeHome.new.run do |home|
@@ -15,6 +17,8 @@ class TestAlias < Minitest::Test
   end
 
   # alias remove <alias>
+  # @todo #322:30min Implement the remove command and unskip this test.
+  #  The syntax is already documented in the alias command in the help.
   def test_remove_removes_the_alias_from_the_alias_file
     skip
     FakeHome.new.run do |home|
@@ -28,6 +32,8 @@ class TestAlias < Minitest::Test
   end
 
   # alias show <alias>
+  # @todo #322:30min Implement the show command and unskip this test.
+  #  The syntax is already documented in the alias command in the help.
   def test_show_prints_out_the_aliased_wallet_id
     skip
     FakeHome.new.run do |home|

--- a/test/commands/test_alias.rb
+++ b/test/commands/test_alias.rb
@@ -11,7 +11,7 @@ class TestAlias < Minitest::Test
       wallet = home.create_wallet
       Zold::Alias.new(wallets: home.wallets, log: test_log).run(%W[set #{wallet.id} my-alias])
       aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
-      assert_equal File.read(path), %W[my-alias #{wallet.id}]
+      assert_equal aliases, %W[my-alias #{wallet.id}]
     end
   end
 
@@ -23,10 +23,9 @@ class TestAlias < Minitest::Test
       cmd = Zold::Alias.new(wallets: home.wallets, log: test_log)
       cmd.run(%W[set #{wallet.id} my-alias])
       aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
-      assert_equal File.read(path), %W[my-alias #{wallet.id}]
-
+      assert_equal aliases, %W[my-alias #{wallet.id}]
       cmd.run(%w[remove my-alias])
-      assert_empty File.read(path)
+      assert_empty aliases
     end
   end
 
@@ -38,7 +37,7 @@ class TestAlias < Minitest::Test
       cmd = Zold::Alias.new(wallets: home.wallets, log: test_log)
       cmd.run(%W[set #{wallet.id} my-alias])
       aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
-      assert_equal File.read(path), %W[my-alias #{wallet.id}]
+      assert_equal aliases, %W[my-alias #{wallet.id}]
       stdout, _ = capture_io { cmd.run(%w[show my-alias]) }
       assert_match wallet.id.to_s, stdout
     end

--- a/test/commands/test_alias.rb
+++ b/test/commands/test_alias.rb
@@ -1,7 +1,34 @@
 require 'minitest/autorun'
+require_relative '../test__helper'
+require_relative '../fake_home'
+require_relative '../../lib/zold/commands/alias'
 
-# @todo #279:30min Write unit tests for the alias command.
-#  It should test all the subcommands (set, remove and show)
-#  and any options.
 class TestAlias < Minitest::Test
+  # alias set <wallet> <alias>
+  def test_set_writes_alias_to_the_alias_file
+    FakeHome.new.run do |home|
+      wallet = home.create_wallet
+      assert_raises NotImplementedError do
+        Zold::Alias.new(wallets: home.wallets, log: test_log).run(['set', wallet.id.to_s, 'my-alias'])
+      end
+    end
+  end
+
+  # alias remove <alias>
+  def test_remove_removes_the_alias_from_the_alias_file
+    FakeHome.new.run do |home|
+      assert_raises NotImplementedError do
+        Zold::Alias.new(wallets: home.wallets, log: test_log).run(['remove', 'my-alias'])
+      end
+    end
+  end
+
+  # alias show <alias>
+  def test_show_prints_out_the_aliased_wallet_id
+    FakeHome.new.run do |home|
+      assert_raises NotImplementedError do
+        Zold::Alias.new(wallets: home.wallets, log: test_log).run(['show', 'my-alias'])
+      end
+    end
+  end
 end

--- a/test/commands/test_alias.rb
+++ b/test/commands/test_alias.rb
@@ -10,8 +10,7 @@ class TestAlias < Minitest::Test
     FakeHome.new.run do |home|
       wallet = home.create_wallet
       Zold::Alias.new(wallets: home.wallets, log: test_log).run(%W[set #{wallet.id} my-alias])
-      aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
-      assert_equal aliases, %W[my-alias #{wallet.id}]
+      assert_equal read_alias_file(home), %W[my-alias #{wallet.id}]
     end
   end
 
@@ -22,10 +21,9 @@ class TestAlias < Minitest::Test
       wallet = home.create_wallet
       cmd = Zold::Alias.new(wallets: home.wallets, log: test_log)
       cmd.run(%W[set #{wallet.id} my-alias])
-      aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
-      assert_equal aliases, %W[my-alias #{wallet.id}]
+      assert_equal read_alias_file(home), %W[my-alias #{wallet.id}]
       cmd.run(%w[remove my-alias])
-      assert_empty aliases
+      assert_empty read_alias_file(home)
     end
   end
 
@@ -36,10 +34,15 @@ class TestAlias < Minitest::Test
       wallet = home.create_wallet
       cmd = Zold::Alias.new(wallets: home.wallets, log: test_log)
       cmd.run(%W[set #{wallet.id} my-alias])
-      aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
-      assert_equal aliases, %W[my-alias #{wallet.id}]
+      assert_equal read_alias_file(home), %W[my-alias #{wallet.id}]
       stdout, _ = capture_io { cmd.run(%w[show my-alias]) }
       assert_match wallet.id.to_s, stdout
     end
+  end
+
+  private
+
+  def read_alias_file(home)
+    File.read(File.join(home.dir, 'aliases')).split(' ')
   end
 end

--- a/test/commands/test_alias.rb
+++ b/test/commands/test_alias.rb
@@ -35,7 +35,7 @@ class TestAlias < Minitest::Test
       cmd = Zold::Alias.new(wallets: home.wallets, log: test_log)
       cmd.run(%W[set #{wallet.id} my-alias])
       assert_equal read_alias_file(home), %W[my-alias #{wallet.id}]
-      stdout, _ = capture_io { cmd.run(%w[show my-alias]) }
+      stdout, = capture_io { cmd.run(%w[show my-alias]) }
       assert_match wallet.id.to_s, stdout
     end
   end

--- a/test/commands/test_alias.rb
+++ b/test/commands/test_alias.rb
@@ -6,29 +6,41 @@ require_relative '../../lib/zold/commands/alias'
 class TestAlias < Minitest::Test
   # alias set <wallet> <alias>
   def test_set_writes_alias_to_the_alias_file
+    skip
     FakeHome.new.run do |home|
       wallet = home.create_wallet
-      assert_raises NotImplementedError do
-        Zold::Alias.new(wallets: home.wallets, log: test_log).run(['set', wallet.id.to_s, 'my-alias'])
-      end
+      Zold::Alias.new(wallets: home.wallets, log: test_log).run(%W[set #{wallet.id} my-alias])
+      aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
+      assert_equal File.read(path), %W[my-alias #{wallet.id}]
     end
   end
 
   # alias remove <alias>
   def test_remove_removes_the_alias_from_the_alias_file
+    skip
     FakeHome.new.run do |home|
-      assert_raises NotImplementedError do
-        Zold::Alias.new(wallets: home.wallets, log: test_log).run(['remove', 'my-alias'])
-      end
+      wallet = home.create_wallet
+      cmd = Zold::Alias.new(wallets: home.wallets, log: test_log)
+      cmd.run(%W[set #{wallet.id} my-alias])
+      aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
+      assert_equal File.read(path), %W[my-alias #{wallet.id}]
+
+      cmd.run(%w[remove my-alias])
+      assert_empty File.read(path)
     end
   end
 
   # alias show <alias>
   def test_show_prints_out_the_aliased_wallet_id
+    skip
     FakeHome.new.run do |home|
-      assert_raises NotImplementedError do
-        Zold::Alias.new(wallets: home.wallets, log: test_log).run(['show', 'my-alias'])
-      end
+      wallet = home.create_wallet
+      cmd = Zold::Alias.new(wallets: home.wallets, log: test_log)
+      cmd.run(%W[set #{wallet.id} my-alias])
+      aliases = File.read(File.join(home.dir, 'aliases')).split(' ')
+      assert_equal File.read(path), %W[my-alias #{wallet.id}]
+      stdout, _ = capture_io { cmd.run(%w[show my-alias]) }
+      assert_match wallet.id.to_s, stdout
     end
   end
 end


### PR DESCRIPTION
#322

**Few side notes:**
- It was explained to me that the process is to start with a skipped tests and a pdd comment. Here, since the command file has been added first and it raises `NotImplementedError`, I don’t skip the test, but I (have to) check whether `NotImplementedError` is raised. Side-advantage of that is once the command is implemented, the tests will fail, prompting whoever is working on it to update them.
- The aforementioned PDD comment is already there (in the command file), hence I’m not introducing a new one.