### PR TITLE
#305 - Removed reference to unused digest library

### DIFF
--- a/lib/zold/tax.rb
+++ b/lib/zold/tax.rb
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-require 'digest'
 require_relative 'key'
 require_relative 'id'
 require_relative 'amount'


### PR DESCRIPTION
Sorry for the additional PR referencing issue #305, I had to remove an unused reference to the digest library that was unused.

