### PR TITLE
Upgrade script to rename wallet -> wallet.z #358

### DIFF
--- a/upgrades/0.0.0.rb
+++ b/upgrades/0.0.0.rb
@@ -1,0 +1,8 @@
+# https://github.com/zold-io/zold/issues/358
+# rename all wallets from their current names into *.z
+
+Dir.glob('*').each do |path|
+  next unless path.match(/^[a-z\d]{16}$/)
+  puts "Renaming #{path} -> #{path}.z"
+  File.rename(path, "#{path}.z")
+end


### PR DESCRIPTION
#358 

**Status:** _This PR is here as a supporting evidence for #372, it's not finished yet._

_At the moment the naming is wrong, it should be `upgrades/2.rb`, but until #369 is implemented, we cannot use the name, because the validation validates `x.y.z` format of version. Once this is done, `PROTOCOL` needs to be bumped._