### PR TITLE
#52 return 402 when wallet is pushed with negative balance

### DIFF
--- a/lib/zold/error.rb
+++ b/lib/zold/error.rb
@@ -1,0 +1,36 @@
+# Copyright (c) 2018 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+module Zold
+  # Errors raised from engine classes
+  module Error
+    # Wallet failed validation
+    class InvalidWallet < StandardError
+    end
+
+    # Non-root wallet has negative balance
+    class NegativeBalance < InvalidWallet
+    end
+
+    # Wallet owes too much tax
+    class TaxDebt < InvalidWallet
+    end
+  end
+end

--- a/lib/zold/node/front.rb
+++ b/lib/zold/node/front.rb
@@ -32,6 +32,7 @@ require_relative '../log'
 require_relative '../id'
 require_relative '../http'
 require_relative '../atomic_file'
+require_relative '../error'
 
 # The web front of the node.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -263,6 +264,12 @@ module Zold
       status 404
       content_type 'text/plain'
       "Page not found: #{request.url}"
+    end
+
+    error Error::NegativeBalance do
+      status 402
+      content_type 'text/plain'
+      env['sinatra.error'].message
     end
 
     error 400 do

--- a/test/node/test_front.rb
+++ b/test/node/test_front.rb
@@ -113,6 +113,19 @@ class FrontTest < Minitest::Test
     end
   end
 
+  def test_402_on_negative_balance
+    FakeHome.new.run do |home|
+      FakeNode.new(log: test_log).run do |port|
+        wallet = home.create_wallet
+        amount = Zold::Amount.new(zld: 39.99)
+        key = Zold::Key.new(file: File.join(home.dir, 'id_rsa'))
+        wallet.sub(amount, "NOPREFIX@#{Zold::Id.new}", key)
+        response = Zold::Http.new("http://localhost:#{port}/wallet/#{wallet.id}?sync=true").put(File.read(wallet.path))
+        assert_equal('402', response.code, response.body)
+      end
+    end
+  end
+
   def test_different_logos
     {
       '0' => 'https://www.zold.io/images/logo-red.png',

--- a/test/node/test_safe_entrance.rb
+++ b/test/node/test_safe_entrance.rb
@@ -36,9 +36,9 @@ class TestSafeEntrance < Minitest::Test
     FakeHome.new.run do |home|
       wallet = home.create_wallet
       amount = Zold::Amount.new(zld: 39.99)
-      key = Zold::Key.new(file: 'fixtures/id_rsa')
+      key = Zold::Key.new(file: File.join(home.dir, 'id_rsa'))
       wallet.sub(amount, "NOPREFIX@#{Zold::Id.new}", key)
-      assert_raises StandardError do
+      assert_raises Zold::Error::NegativeBalance do
         Zold::SafeEntrance.new(FakeEntrance.new).push(wallet.id, File.read(wallet.path))
       end
     end
@@ -48,7 +48,7 @@ class TestSafeEntrance < Minitest::Test
     FakeHome.new.run do |home|
       wallet = Zold::Wallet.new(File.join(home.dir, 'wallet'))
       wallet.init(Zold::Id.new, Zold::Key.new(file: 'fixtures/id_rsa.pub'), network: 'someothernetwork')
-      assert_raises StandardError do
+      assert_raises Zold::Error::InvalidWallet do
         Zold::SafeEntrance.new(FakeEntrance.new).push(wallet.id, File.read(wallet.path))
       end
     end


### PR DESCRIPTION
Fixes #52

- Add namespace for custom exceptions `Zold::Error::`
- Node returns 402 Payment Required from negative balance wallet push