### PR TITLE
Issue #394 - Refactoring Zold::Remotes class to use dry-types

### DIFF
--- a/bin/zold
+++ b/bin/zold
@@ -149,7 +149,7 @@ Available options:"
   Zold::RenameForeignWallets.new(Dir.pwd, opts['network'], log).exec
 
   wallets = Zold::Wallets.new('.')
-  remotes = Zold::Remotes.new('./.zoldata/remotes', network: opts['network'])
+  remotes = Zold::Remotes.new(file: './.zoldata/remotes', network: opts['network'])
   copies = './.zoldata/copies'
 
   case command

--- a/lib/zold/commands/node.rb
+++ b/lib/zold/commands/node.rb
@@ -149,7 +149,7 @@ module Zold
         AccessLog: []
       )
       if opts['standalone']
-        @remotes = Remotes::Empty.new
+        @remotes = Zold::Remotes::Empty.new(file: '/tmp/standalone')
         @log.debug('Running in standalone mode! (will never talk to other remotes)')
       end
       Front.set(:ignore_score_weakness, opts['ignore-score-weakness'])

--- a/lib/zold/remotes.rb
+++ b/lib/zold/remotes.rb
@@ -28,6 +28,7 @@ require 'fileutils'
 require_relative 'backtrace'
 require_relative 'node/farm'
 require_relative 'atomic_file'
+require_relative 'type'
 
 # The list of remotes.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -35,7 +36,7 @@ require_relative 'atomic_file'
 # License:: MIT
 module Zold
   # All remotes
-  class Remotes
+  class Remotes < Dry::Struct
     # The default TCP port all nodes are supposed to use.
     PORT = 4096
 
@@ -48,12 +49,12 @@ module Zold
     # Default number of nodes to fetch.
     MAX_NODES = 16
 
+    attribute :file, Types::Strict::String
+    attribute :network, Types::Strict::String.optional.default('test')
+    attribute :mutex, meta(omittable: true)
+
     # Empty, for standalone mode
     class Empty < Remotes
-      def initialize
-        # Nothing here
-      end
-
       def all
         []
       end
@@ -64,33 +65,28 @@ module Zold
     end
 
     # One remote.
-    class Remote
-      attr_reader :host, :port
-      def initialize(host, port, score, idx, log: Log::Quiet.new, network: 'test')
-        @host = host
-        raise 'Post must be Integer' unless port.is_a?(Integer)
-        @port = port
-        raise 'Score must be of type Score' unless score.is_a?(Score)
-        @score = score
-        raise 'Idx must be of type Integer' unless idx.is_a?(Integer)
-        @idx = idx
-        raise 'Network can\'t be nil' if network.nil?
-        @network = network
-        @log = log
-      end
+    class Remote < Dry::Struct
+      attribute :host, Types::Strict::String
+      attribute :port, Types::Strict::Integer.constrained(gteq: 0, lt: 65_535)
+      attribute :score, Score
+      attribute :idx, Types::Strict::Integer
+      attribute :network, Types::Strict::String.optional.default('test')
+      attribute :log, (Types::Class.constructor do |value|
+        value.nil? ? Log::Quiet.new : value
+      end)
 
       def http(path = '/')
-        Http.new(uri: "http://#{@host}:#{@port}#{path}", score: @score, network: @network)
+        Http.new(uri: "http://#{host}:#{port}#{path}", score: score, network: network)
       end
 
       def to_s
-        "#{@host}:#{@port}/#{@idx}"
+        "#{host}:#{port}/#{idx}"
       end
 
       def assert_code(code, response)
         msg = response.message.strip
         return if response.code.to_i == code
-        @log.debug("#{response.code} \"#{response.message}\" at \"#{response.body}\"")
+        log.debug("#{response.code} \"#{response.message}\" at \"#{response.body}\"")
         raise "Unexpected HTTP code #{response.code}, instead of #{code}" if msg.empty?
         raise "#{msg} (HTTP code #{response.code}, instead of #{code})"
       end
@@ -101,8 +97,8 @@ module Zold
       end
 
       def assert_score_ownership(score)
-        raise "Masqueraded host #{@host} as #{score.host}: #{score}" if @host != score.host
-        raise "Masqueraded port #{@port} as #{score.port}: #{score}" if @port != score.port
+        raise "Masqueraded host #{host} as #{score.host}: #{score}" if host != score.host
+        raise "Masqueraded port #{port} as #{score.port}: #{score}" if port != score.port
       end
 
       def assert_score_strength(score)
@@ -112,14 +108,6 @@ module Zold
       def assert_score_value(score, min)
         raise "Score is too small (<#{min}): #{score}" if score.value < min
       end
-    end
-
-    def initialize(file, network: 'test')
-      raise 'File can\'t be nil' if file.nil?
-      @file = file
-      raise 'Network can\'t be nil' if network.nil?
-      @network = network
-      @mutex = Mutex.new
     end
 
     def all
@@ -138,10 +126,10 @@ module Zold
     end
 
     def reset
-      FileUtils.mkdir_p(File.dirname(@file))
+      FileUtils.mkdir_p(File.dirname(file))
       FileUtils.copy(
         File.join(File.dirname(__FILE__), '../../resources/remotes'),
-        @file
+        file
       )
     end
 
@@ -191,7 +179,14 @@ module Zold
           Thread.current.priority = -100
           start = Time.now
           begin
-            yield Remotes::Remote.new(r[:host], r[:port], score, idx, log: log, network: @network)
+            yield Remotes::Remote.new(
+              host: r[:host],
+              port: r[:port],
+              score: score,
+              idx: idx,
+              log: log,
+              network: network
+            )
             idx += 1
             raise 'Took too long to execute' if (Time.now - start).round > Remotes::RUNTIME_LIMIT
           rescue StandardError => e
@@ -243,8 +238,8 @@ in #{(Time.now - start).round}s; errors=#{errors}")
     end
 
     def load
-      @mutex.synchronize do
-        raw = CSV.read(file).map do |r|
+      _mutex.synchronize do
+        raw = CSV.read(_file).map do |r|
           {
             host: r[0],
             port: r[1].to_i,
@@ -260,8 +255,8 @@ in #{(Time.now - start).round}s; errors=#{errors}")
     end
 
     def save(list)
-      @mutex.synchronize do
-        AtomicFile.new(file).write(
+      _mutex.synchronize do
+        AtomicFile.new(_file).write(
           list.uniq { |r| "#{r[:host]}:#{r[:port]}" }.map do |r|
             [
               r[:host],
@@ -274,9 +269,13 @@ in #{(Time.now - start).round}s; errors=#{errors}")
       end
     end
 
-    def file
-      reset unless File.exist?(@file)
-      @file
+    def _mutex
+      mutex.nil? ? Mutex.new : mutex
+    end
+
+    def _file
+      reset unless File.exist?(file)
+      file
     end
   end
 end

--- a/test/commands/routines/test_reconnect.rb
+++ b/test/commands/routines/test_reconnect.rb
@@ -34,7 +34,7 @@ require_relative '../../../lib/zold/commands/routines/reconnect.rb'
 class TestReconnect < Minitest::Test
   def test_reconnects
     Dir.mktmpdir 'test' do |dir|
-      remotes = Zold::Remotes.new(File.join(dir, 'remotes.csv'))
+      remotes = Zold::Remotes.new(file: File.join(dir, 'remotes.csv'))
       remotes.clean
       stub_request(:get, 'http://b1.zold.io:80/remotes').to_return(status: 404)
       opts = { 'never-reboot' => true, 'routine-immediately' => true }

--- a/test/commands/test_remote.rb
+++ b/test/commands/test_remote.rb
@@ -39,7 +39,7 @@ require_relative '../../lib/zold/commands/remote'
 class TestRemote < Minitest::Test
   def test_updates_remote
     Dir.mktmpdir 'test' do |dir|
-      remotes = Zold::Remotes.new(File.join(dir, 'a/b/c/remotes'))
+      remotes = Zold::Remotes.new(file: File.join(dir, 'a/b/c/remotes'))
       zero = Zold::Score::ZERO
       stub_request(:get, "http://#{zero.host}:#{zero.port}/remotes").to_return(
         status: 200,
@@ -75,7 +75,7 @@ class TestRemote < Minitest::Test
   def test_elects_a_remote
     Dir.mktmpdir 'test' do |dir|
       zero = Zold::Score::ZERO
-      remotes = Zold::Remotes.new(File.join(dir, 'remotes.txt'))
+      remotes = Zold::Remotes.new(file: File.join(dir, 'remotes.txt'))
       remotes.clean
       remotes.add(zero.host, zero.port)
       stub_request(:get, "http://#{zero.host}:#{zero.port}/").to_return(
@@ -93,7 +93,7 @@ class TestRemote < Minitest::Test
 
   def test_remote_trim_with_tolerate
     Dir.mktmpdir 'test' do |dir|
-      remotes = Zold::Remotes.new(File.join(dir, 'remotes.txt'))
+      remotes = Zold::Remotes.new(file: File.join(dir, 'remotes.txt'))
       zero = Zold::Score::ZERO
       stub_request(:get, "http://#{zero.host}:#{zero.port}/remotes").to_return(
         status: 200,
@@ -128,7 +128,7 @@ class TestRemote < Minitest::Test
 
   def test_select_respects_max_nodes_option
     Dir.mktmpdir 'test' do |dir|
-      remotes = Zold::Remotes.new(File.join(dir, 'remotes.txt'))
+      remotes = Zold::Remotes.new(file: File.join(dir, 'remotes.txt'))
       zero = Zold::Score::ZERO
       cmd = Zold::Remote.new(remotes: remotes, log: test_log)
       (5000..5010).each do |port|

--- a/test/fake_home.rb
+++ b/test/fake_home.rb
@@ -58,7 +58,7 @@ class FakeHome
   end
 
   def remotes
-    remotes = Zold::Remotes.new(File.join(@dir, 'secrets/remotes'))
+    remotes = Zold::Remotes.new(file: File.join(@dir, 'secrets/remotes'))
     remotes.clean
     remotes
   end

--- a/test/test_remotes.rb
+++ b/test/test_remotes.rb
@@ -47,7 +47,7 @@ class TestRemotes < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'remotes')
       FileUtils.touch(file)
-      remotes = Zold::Remotes.new(file)
+      remotes = Zold::Remotes.new(file: file)
       remotes.add('127.0.0.1')
       assert(1, remotes.all.count)
     end
@@ -63,7 +63,7 @@ class TestRemotes < Minitest::Test
         "\n\n\n\n"
       ].each do |t|
         File.write(file, t)
-        remotes = Zold::Remotes.new(file)
+        remotes = Zold::Remotes.new(file: file)
         assert(remotes.all.empty?, remotes.all)
       end
     end
@@ -73,7 +73,7 @@ class TestRemotes < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'remotes')
       FileUtils.touch(file)
-      remotes = Zold::Remotes.new(file)
+      remotes = Zold::Remotes.new(file: file)
       ips = (0..50)
       ips.each { |i| remotes.add("0.0.0.#{i}", 9999) }
       remotes.iterate(Zold::Log::Quiet.new) { raise 'Intended' }
@@ -85,7 +85,7 @@ class TestRemotes < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'remotes')
       FileUtils.touch(file)
-      remotes = Zold::Remotes.new(file)
+      remotes = Zold::Remotes.new(file: file)
       remotes.add('0.0.0.1', 9999)
       log = TestLogger.new
       remotes.iterate(log) { raise 'Intended' }
@@ -97,7 +97,7 @@ class TestRemotes < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'remotes')
       FileUtils.touch(file)
-      remotes = Zold::Remotes.new(file)
+      remotes = Zold::Remotes.new(file: file)
       remotes.add('127.0.0.1')
       log = TestLogger.new
       remotes.iterate(log) { sleep(17) }
@@ -109,7 +109,7 @@ class TestRemotes < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'remotes')
       FileUtils.touch(file)
-      remotes = Zold::Remotes.new(file)
+      remotes = Zold::Remotes.new(file: file)
       remotes.add('127.0.0.1')
       remotes.add('LOCALHOST', 433)
       remotes.remove('localhost', 433)
@@ -119,7 +119,7 @@ class TestRemotes < Minitest::Test
 
   def test_resets_remotes
     Dir.mktmpdir 'test' do |dir|
-      remotes = Zold::Remotes.new(File.join(dir, 'remotes'))
+      remotes = Zold::Remotes.new(file: File.join(dir, 'remotes'))
       remotes.clean
       remotes.reset
       remotes.reset
@@ -131,7 +131,7 @@ class TestRemotes < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'remotes')
       FileUtils.touch(file)
-      remotes = Zold::Remotes.new(file)
+      remotes = Zold::Remotes.new(file: file)
       remotes.add('127.0.0.1', 1024)
       remotes.rescore('127.0.0.1', 1024, 15)
       remotes.all.each do |r|
@@ -144,7 +144,7 @@ class TestRemotes < Minitest::Test
   def test_tolerates_invalid_requests
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'remotes')
-      remotes = Zold::Remotes.new(file)
+      remotes = Zold::Remotes.new(file: file)
       remotes.error('127.0.0.1', 1024)
       remotes.rescore('127.0.0.1', 1024, 15)
     end
@@ -152,7 +152,7 @@ class TestRemotes < Minitest::Test
 
   def test_modifies_from_many_threads
     Dir.mktmpdir 'test' do |dir|
-      remotes = Zold::Remotes.new(File.join(dir, 'a.csv'))
+      remotes = Zold::Remotes.new(file: File.join(dir, 'a.csv'))
       remotes.clean
       threads = 5
       pool = Concurrent::FixedThreadPool.new(threads)
@@ -179,5 +179,10 @@ class TestRemotes < Minitest::Test
       assert_equal(cycles.value, success.value)
       assert_equal(0, remotes.all.reject { |r| r[:host] == host }.size)
     end
+  end
+
+  def test_empty_remotes
+    remotes = Zold::Remotes::Empty.new(file: '/tmp/empty')
+    assert(remotes.is_a?(Zold::Remotes))
   end
 end


### PR DESCRIPTION
For issue #394 I have refactored the Zold::Remotes, Zold::Remotes::Empty and Zold::Remotes::Remote classes to use the new dry-types paradigm. I had also to update all involved test cases.
