### PR TITLE
Issue #324 - Adding new test for pull showing how to mock a pull wallet

### DIFF
--- a/test/commands/test_pull.rb
+++ b/test/commands/test_pull.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2018 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'minitest/autorun'
+require 'webmock/minitest'
+require_relative '../fake_home'
+require_relative '../test__helper'
+require_relative '../../lib/zold/id'
+require_relative '../../lib/zold/json_page'
+require_relative '../../lib/zold/commands/pull'
+
+# PUSH test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2018 Yegor Bugayenko
+# License:: MIT
+class TestPull < Minitest::Test
+  def test_pull_wallet
+    FakeHome.new.run do |home|
+      remotes = home.remotes
+      remotes.add('localhost', 80)
+      wallet_json = home.create_wallet_json
+
+      wallet_id = Zold::JsonPage.new(wallet_json).to_hash['id']
+      stub_request(:get, "http://localhost:80/wallet/#{wallet_id}").to_return(status: 200, body: wallet_json)
+      Zold::Pull.new(wallets: home.wallets, remotes: remotes, copies: home.copies.root.to_s, log: test_log).run(
+        ['--ignore-this-stupid-option', 'pull', wallet_id.to_s]
+      )
+      assert(home.wallets.find(Zold::Id.new(wallet_id)).exists?)
+    end
+  end
+end

--- a/test/commands/test_pull.rb
+++ b/test/commands/test_pull.rb
@@ -37,14 +37,13 @@ class TestPull < Minitest::Test
     FakeHome.new.run do |home|
       remotes = home.remotes
       remotes.add('localhost', 80)
-      wallet_json = home.create_wallet_json
-
-      wallet_id = Zold::JsonPage.new(wallet_json).to_hash['id']
-      stub_request(:get, "http://localhost:80/wallet/#{wallet_id}").to_return(status: 200, body: wallet_json)
+      json = home.create_wallet_json
+      id = Zold::JsonPage.new(json).to_hash['id']
+      stub_request(:get, "http://localhost:80/wallet/#{id}").to_return(status: 200, body: json)
       Zold::Pull.new(wallets: home.wallets, remotes: remotes, copies: home.copies.root.to_s, log: test_log).run(
-        ['--ignore-this-stupid-option', 'pull', wallet_id.to_s]
+        ['--ignore-this-stupid-option', 'pull', id.to_s]
       )
-      assert(home.wallets.find(Zold::Id.new(wallet_id)).exists?)
+      assert(home.wallets.find(Zold::Id.new(id)).exists?)
     end
   end
 end

--- a/test/fake_home.rb
+++ b/test/fake_home.rb
@@ -25,6 +25,9 @@ require_relative '../lib/zold/id'
 require_relative '../lib/zold/wallet'
 require_relative '../lib/zold/wallets'
 require_relative '../lib/zold/key'
+require_relative '../lib/zold/version'
+require_relative '../lib/zold/remotes'
+require_relative '../lib/zold/atomic_file'
 
 # Fake home dir.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -47,10 +50,29 @@ class FakeHome
     Zold::Wallets.new(@dir)
   end
 
-  def create_wallet(id = Zold::Id.new)
-    wallet = Zold::Wallet.new(File.join(@dir, id.to_s))
+  def create_wallet(id = Zold::Id.new, dir = @dir)
+    wallet = Zold::Wallet.new(File.join(dir, id.to_s))
     wallet.init(id, Zold::Key.new(file: File.join(__dir__, '../fixtures/id_rsa.pub')))
     wallet
+  end
+
+  def create_wallet_json(id = Zold::Id.new)
+    require_relative '../lib/zold/score'
+    score = Zold::Score::ZERO
+    Dir.mktmpdir 'wallets' do |external_dir|
+      wallet = create_wallet(id, external_dir)
+      {
+        version: Zold::VERSION,
+        protocol: Zold::PROTOCOL,
+        id: wallet.id.to_s,
+        score: score.to_h,
+        wallets: 1,
+        mtime: wallet.mtime.utc.iso8601,
+        digest: wallet.digest,
+        balance: wallet.balance.to_i,
+        body: Zold::AtomicFile.new(wallet.path).read
+      }.to_json
+    end
   end
 
   def copies(wallet = create_wallet)


### PR DESCRIPTION
As requested in issue #324, I have created a test for pull command showing hot to mock a pull request of a wallet.

Basically this is what I am doing:

- Add a mock remote;
- Generating a fake response for a wallet, by creating a proper wallet (in a separate directory);
- stubbing the response of _/wallet_ call;
- execute the _Pull_ command;
- testing if the wallet has been correctly merged;