### PR TITLE
Issue 249 - Node alias

### DIFF
--- a/lib/zold/commands/node.rb
+++ b/lib/zold/commands/node.rb
@@ -123,6 +123,9 @@ module Zold
           'Don\'t run the metronome',
           required: true,
           default: false
+        o.string '--alias',
+          'The alias of the node (default: host:port)',
+          require: false
         o.bool '--help', 'Print instructions'
       end
       if opts.help?
@@ -171,6 +174,8 @@ module Zold
       Front.set(:dump_errors, opts['dump-errors'])
       Front.set(:port, opts['bind-port'])
       Front.set(:reboot, !opts['never-reboot'])
+      node_alias = opts[:alias] || address
+      Front.set(:node_alias, node_alias)
       invoice = opts[:invoice]
       unless invoice.include?('@')
         if @wallets.find(Id.new(invoice)).exists?

--- a/lib/zold/commands/node.rb
+++ b/lib/zold/commands/node.rb
@@ -175,6 +175,11 @@ module Zold
       Front.set(:port, opts['bind-port'])
       Front.set(:reboot, !opts['never-reboot'])
       node_alias = opts[:alias] || address
+      unless node_alias.eql?(address)
+        re = Regexp.new(/^[a-z0-9]{4,16}$/)
+        puts re.match(node_alias)
+        raise '--alias should be a 4 to 16 char long alphanumeric string' unless re.match(node_alias)
+      end
       Front.set(:node_alias, node_alias)
       invoice = opts[:invoice]
       unless invoice.include?('@')

--- a/lib/zold/commands/node.rb
+++ b/lib/zold/commands/node.rb
@@ -177,7 +177,6 @@ module Zold
       node_alias = opts[:alias] || address
       unless node_alias.eql?(address)
         re = Regexp.new(/^[a-z0-9]{4,16}$/)
-        puts re.match(node_alias)
         raise '--alias should be a 4 to 16 char long alphanumeric string' unless re.match(node_alias)
       end
       Front.set(:node_alias, node_alias)

--- a/lib/zold/node/front.rb
+++ b/lib/zold/node/front.rb
@@ -66,6 +66,7 @@ module Zold
       set :wallets, nil? # to be injected at node.rb
       set :remotes, nil? # to be injected at node.rb
       set :copies, nil? # to be injected at node.rb
+      set :node_alias, nil? # to be injected at node.rb
     end
     use Rack::Deflater
 
@@ -148,6 +149,7 @@ while #{settings.address} is in '#{settings.network}'"
       content_type 'application/json'
       JSON.pretty_generate(
         version: settings.version,
+        alias: settings.node_alias,
         network: settings.network,
         protocol: settings.protocol,
         score: score.to_h,
@@ -174,6 +176,7 @@ while #{settings.address} is in '#{settings.network}'"
       content_type 'application/json'
       {
         version: settings.version,
+        alias: settings.node_alias,
         protocol: settings.protocol,
         id: wallet.id.to_s,
         score: score.to_h,
@@ -192,6 +195,7 @@ while #{settings.address} is in '#{settings.network}'"
       content_type 'application/json'
       {
         version: settings.version,
+        alias: settings.node_alias,
         protocol: settings.protocol,
         id: wallet.id.to_s,
         score: score.to_h,
@@ -266,6 +270,7 @@ while #{settings.address} is in '#{settings.network}'"
       end
       JSON.pretty_generate(
         version: settings.version,
+        alias: settings.node_alias,
         score: score.to_h,
         wallets: settings.wallets.all.count
       )
@@ -275,6 +280,7 @@ while #{settings.address} is in '#{settings.network}'"
       content_type 'application/json'
       JSON.pretty_generate(
         version: settings.version,
+        alias: settings.node_alias,
         score: score.to_h,
         all: settings.remotes.all
       )

--- a/test/node/test_front.rb
+++ b/test/node/test_front.rb
@@ -220,7 +220,7 @@ class FrontTest < Minitest::Test
   end
 
   def test_alias_parameter
-    name = SecureRandom.hex
+    name = SecureRandom.hex(4)
     FakeNode.new(log: test_log).run(['--ignore-score-weakness', "--alias=#{name}"]) do |port|
       [
         '/',
@@ -247,5 +247,15 @@ class FrontTest < Minitest::Test
         response.body
       )
     end
+  end
+
+  def test_invalid_alias
+    exception = assert_raises RuntimeError do
+      FakeNode.new(log: test_log).run(['--ignore-score-weakness', '--alias=invalid-alias']) do |port|
+        uri = URI("http://localhost:#{port}/")
+        Zold::Http.new(uri: uri, score: nil).get
+      end
+    end
+    assert_equal('--alias should be a 4 to 16 char long alphanumeric string', exception.message)
   end
 end


### PR DESCRIPTION
For issue #249 I added a new _alias_ parameter to _node_ command to assign an alphanumeric string to a node. This string is then included in the mail REST responses.

Please note that _alias_ is a reserved word, so I hade to call the internal attribute _node_alias_ to avoid conflicts