### PR TITLE
Issue #231 - Downloading openssl headers for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,13 +13,24 @@ environment:
     - RUBY_VERSION: 24
     - RUBY_VERSION: 25
 install:
-  - cmd: set PATH=C:\Ruby%RUBY_VERSION%-X64\bin;%PATH%
+  - ps: |
+      $Env:PATH = "C:\Ruby${Env:ruby_version}-X64\bin;${Env:PATH}"
+      if ($Env:ruby_version -match "^23" ) {
+        # RubyInstaller; download OpenSSL headers from OpenKnapsack Project
+        $Env:openssl_dir = "C:\Ruby${Env:ruby_version}"
+        appveyor DownloadFile http://dl.bintray.com/oneclick/OpenKnapsack/x64/openssl-1.0.2j-x64-windows.tar.lzma
+        7z e openssl-1.0.2j-x64-windows.tar.lzma
+        7z x -y -oC:\Ruby${Env:ruby_version} openssl-1.0.2j-x64-windows.tar
+      } else {
+        # RubyInstaller2; openssl package seems to be installed already
+        $Env:openssl_dir = "C:\msys64\mingw64"
+      }
   - cmd: ruby --version
   - cmd: git --version
   - cmd: bundle config --local path vendor/bundle
 build_script:
-  - bundle update
-  - bundle install
+  - bundle update --with-openssl-dir=%openssl_dir%
+  - bundle install --with-openssl-dir=%openssl_dir%
 test_script:
   - rake
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ install:
   - cmd: git --version
   - cmd: bundle config --local path vendor/bundle
 build_script:
-  - bundle update --with-openssl-dir=%openssl_dir%
-  - bundle install --with-openssl-dir=%openssl_dir%
+  - bundle update
+  - bundle install
 test_script:
   - rake
 cache:


### PR DESCRIPTION
For appveyor in issue #231  to successfully build openssl, we have to download precompiled headers for Windows and use them for bundle