### PR TITLE
#134 - remove node itself from remote while node onboarding

### DIFF
--- a/lib/zold/commands/node.rb
+++ b/lib/zold/commands/node.rb
@@ -167,6 +167,7 @@ module Zold
         @log.debug('Running in standalone mode! (will never talk to other remotes)')
       else
         Zold::Remote.new(remotes: @remotes).run(['remote', 'remove', host, port.to_s, '--force'])
+        @log.info("Removed current node (#{address}) from list of remotes")
       end
       Front.set(:ignore_score_weakness, opts['ignore-score-weakness'])
       Front.set(:network, opts['network'])

--- a/lib/zold/commands/node.rb
+++ b/lib/zold/commands/node.rb
@@ -41,6 +41,7 @@ require_relative '../node/farm'
 require_relative 'pull'
 require_relative 'push'
 require_relative 'pay'
+require_relative 'remote'
 
 # NODE command.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -152,7 +153,8 @@ module Zold
       @log.info("Zold protocol version: #{Zold::PROTOCOL}")
       @log.info("Network ID: #{opts['network']}")
       host = opts[:host] || ip
-      address = "#{host}:#{opts[:port]}".downcase
+      port = opts[:port]
+      address = "#{host}:#{port}".downcase
       @log.info("Node location: #{address}")
       @log.info("Local address: http://localhost:#{opts['bind-port']}/")
       Front.set(
@@ -163,6 +165,8 @@ module Zold
       if opts['standalone']
         @remotes = Zold::Remotes::Empty.new(file: '/tmp/standalone')
         @log.debug('Running in standalone mode! (will never talk to other remotes)')
+      else
+        Zold::Remote.new(remotes: @remotes).run(['remote', 'remove', host, port.to_s, '--force'])
       end
       Front.set(:ignore_score_weakness, opts['ignore-score-weakness'])
       Front.set(:network, opts['network'])


### PR DESCRIPTION
PR for #134 

remove node itself from remote while node onboarding using `remote` command. `--force` argument prevents to fail if current node is not in `remotes` list.