### PR TITLE
Issue #333 Adds Hungry Wallet

### DIFF
--- a/lib/zold/commands/node.rb
+++ b/lib/zold/commands/node.rb
@@ -30,6 +30,7 @@ require_relative '../age'
 require_relative '../metronome'
 require_relative '../wallet'
 require_relative '../wallets'
+require_relative '../hungry_wallets'
 require_relative '../remotes'
 require_relative '../verbose_thread'
 require_relative '../node/farmers'
@@ -58,7 +59,7 @@ module Zold
       @remotes = remotes
       @copies = copies
       @log = log
-      @wallets = wallets
+      @wallets = HungryWallets.new(wallets, @remotes, @copies)
     end
 
     def run(args = [])

--- a/lib/zold/hungry_wallets.rb
+++ b/lib/zold/hungry_wallets.rb
@@ -34,10 +34,16 @@ module Zold
     end
 
     def find(id)
-      Zold::Pull.new(wallets: @wallets, remotes: @remotes, copies: @copies).run(['pull', id.to_s, '--quiet-if-absent']) unless File.exist?(File.join(@wallets.path, id.to_s + Wallet::EXT))
+      Zold::Pull.new(wallets: @wallets, remotes: @remotes, copies: @copies).run(['pull', id.to_s, '--quiet-if-absent']) unless wallet_present?(id)
       super(id) do |wallet|
         yield wallet
       end
+    end
+
+    private
+
+    def wallet_present?(id)
+      File.exist?(File.join(@wallets.path, id.to_s + Wallet::EXT))
     end
   end
 end

--- a/test/test_hungry_wallet.rb
+++ b/test/test_hungry_wallet.rb
@@ -41,7 +41,7 @@ class TestHungryWallets < Zold::Test
       json = home.create_wallet_json
       id = Zold::JsonPage.new(json).to_hash['id']
       stub_request(:get, "http://localhost:4096/wallet/#{id}").to_return(status: 200, body: json)
-      FileUtils.rm(["#{home.dir}/#{id}#{Zold::Wallet::EXT}", "#{home.dir}/#{id}#{Zold::Wallet::EXT}.lock"])
+      FileUtils.rm(["#{home.wallets.path}/#{id}#{Zold::Wallet::EXT}", "#{home.wallets.path}/#{id}#{Zold::Wallet::EXT}.lock"])
       wallets = Zold::HungryWallets.new(home.wallets, remotes, home.copies.root.to_s)
       wallets.find(Zold::Id.new(id)) do |wallet|
         assert(wallet.exists?)


### PR DESCRIPTION
#333 
I'm not sure if using this line on the test is correct: 
 `FileUtils.rm(["#{home.dir}/#{id}#{Zold::Wallet::EXT}", "#{home.dir}/#{id}#{Zold::Wallet::EXT}.lock"])`
but I couldn't find another way of not having the file on my system so I could test the pull when the file isn't present.