### PR TITLE
Issue #553 - Redeploy on upgrade fix

### DIFF
--- a/fixtures/scripts/redeploy-on-upgrade.sh
+++ b/fixtures/scripts/redeploy-on-upgrade.sh
@@ -7,7 +7,7 @@ function start_node {
   zold node $3 --nohup --nohup-command='touch restarted' --nohup-log=log --nohup-max-cycles=0 --nohup-log-truncate=10240 \
     --expose-version=$2 --save-pid=pid --routine-immediately \
     --verbose --trace --invoice=REDEPLOY@ffffffffffffffff \
-    --host=127.0.0.1 --port=$1 --bind-port=$1 --threads=1 --strength=20 --memory-dump > /dev/null 2>&1
+    --host=127.0.0.1 --port=$1 --bind-port=$1 --threads=1 --strength=20 > /dev/null 2>&1
   wait_for_port $1
   cat pid
   cd ..


### PR DESCRIPTION
Trying to fix the problem reported in issue #553 I run many times `rake` but just a few times the test on subject failed, so it is really difficult to find the reason why of the failing.

Also, the output in the failing case doesn't differs that much from the good one.

By analyzing the code however, I noticed that only on that particular test it was added the `--memory-dump` option, that is used to check memory consumption by the library. 

It is not required in this test to check the memory usage, and also it is specified in `memory profiler gem` that by using it it could slow down the application, and this could be a reason why sometimes the test fails.

Therefore, I just removed that option, let's see if the problem arises again in the future.