### PR TITLE
[#574] fixes Appveyor build (libcurl is not found)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,11 @@ install:
         # RubyInstaller2; openssl package seems to be installed already
         $Env:openssl_dir = "C:\msys64\mingw64"
       }
+
+      appveyor DownloadFile http://www.dlldownloader.com/libcurl-dll/download/926e6b36f389ef68ec7806c865803780/ curl-win32-mingw.7z
+      7z e curl-win32-mingw.7z
+      dir
+
   - bundle config --local path vendor/bundle
   - bundle config build.openssl --with-openssl-dir=%openssl_dir%
   - ruby -v


### PR DESCRIPTION
![screen shot 2018-11-26 at 19 54 16](https://user-images.githubusercontent.com/31139/49029196-17794c00-f1b5-11e8-8fc7-5cb20a617e5c.png)

There are still exists another issues but building `patron` with `lcurl` is fixed