### PR TITLE
[#574] fix Appveyor build: libcurl is not found

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,15 @@ install:
         # RubyInstaller2; openssl package seems to be installed already
         $Env:openssl_dir = "C:\msys64\mingw64"
       }
+
+      # Install libcurl for patron
+      appveyor DownloadFile https://curl.haxx.se/windows/dl-7.62.0_1/curl-7.62.0_1-win64-mingw.zip
+      7z x -y -oC:\Ruby${Env:ruby_version} curl-7.62.0_1-win64-mingw.zip
+      $Env:curl_dir = "C:\Ruby${Env:ruby_version}\curl-7.62.0-win64-mingw"
+
   - bundle config --local path vendor/bundle
   - bundle config build.openssl --with-openssl-dir=%openssl_dir%
+  - bundle config build.patron --with-curl-dir=%curl_dir%
   - ruby -v
   - bundle -v
 build_script:


### PR DESCRIPTION
https://github.com/zold-io/zold/issues/574

![screen shot 2018-11-26 at 19 54 16](https://user-images.githubusercontent.com/31139/49029196-17794c00-f1b5-11e8-8fc7-5cb20a617e5c.png)

There are still exists another issues but building `patron` with `curl` is fixed