### PR TITLE
Remove unnecessary escaping for shell commands in DirItems

### DIFF
--- a/lib/zold/dir_items.rb
+++ b/lib/zold/dir_items.rb
@@ -42,7 +42,7 @@ module Zold
     def fetch(recursive: true)
       spawn = POSIX::Spawn::Child.new(
         'find',
-        *([Shellwords.escape(@dir), '-type', 'f', '-print'] + (recursive ? [] : ['-maxdepth', '1']))
+        *([@dir, '-type', 'f', '-print'] + (recursive ? [] : ['-maxdepth', '1']))
       )
       raise spawn.err unless spawn.status.success?
       spawn.out

--- a/test/test_dir_items.rb
+++ b/test/test_dir_items.rb
@@ -57,7 +57,6 @@ class TestDirItems < Zold::Test
   #  mission critical, since we don't have spaces in our paths, mostly. But
   #  still, would be great to fix it.
   def test_lists_empty_dir
-    skip
     Dir.mktmpdir do |dir|
       d = File.join(dir, 'path с пробелами')
       FileUtils.mkdir_p(d)

--- a/test/test_dir_items.rb
+++ b/test/test_dir_items.rb
@@ -53,9 +53,6 @@ class TestDirItems < Zold::Test
     end
   end
 
-  # @todo #507:30min I don't understand why this test doesn't work. It's not
-  #  mission critical, since we don't have spaces in our paths, mostly. But
-  #  still, would be great to fix it.
   def test_lists_empty_dir
     Dir.mktmpdir do |dir|
       d = File.join(dir, 'path с пробелами')


### PR DESCRIPTION
#511
It seems that **Shellwords::escape** output is incompatible with **POSIX::Spawn::Child**. Sending the shell command arguments works fine without escaping them with **Shellwords::escape**. 