### PR TITLE
[#581] remove bundle update from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,6 @@ build_script:
   # https://github.com/eventmachine/eventmachine/issues/800
   #
   - gem install eventmachine --platform ruby
-  - bundle update
   - bundle install
 test_script:
   - bundle exec rake --quiet


### PR DESCRIPTION
Just removes bundle update from appveyor. We need to work with locked gems versions only.