### PR TITLE
#514 improve total_wallets count

### DIFF
--- a/lib/zold/cached_wallets.rb
+++ b/lib/zold/cached_wallets.rb
@@ -53,6 +53,10 @@ module Zold
       @wallets.all
     end
 
+    def count
+      @wallets.count
+    end
+
     def acq(id, exclusive: false)
       @wallets.acq(id, exclusive: exclusive) do |wallet|
         c = @zache.get(id.to_s, lifetime: 5 * 60) { wallet }

--- a/lib/zold/node/front.rb
+++ b/lib/zold/node/front.rb
@@ -456,7 +456,7 @@ time to stop; use --skip-oom to never quit")
     def total_wallets
       return 256 if settings.opts['network'] == Wallet::MAINET
       settings.zache.get(:wallets, lifetime: settings.opts['no-cache'] ? 0 : 60) do
-        settings.wallets.all.count
+        settings.wallets.count
       end
     end
 

--- a/lib/zold/sync_wallets.rb
+++ b/lib/zold/sync_wallets.rb
@@ -51,6 +51,10 @@ module Zold
       @wallets.all
     end
 
+    def count
+      @wallets.count
+    end
+
     def acq(id, exclusive: false)
       @wallets.acq(id, exclusive: exclusive) do |wallet|
         Futex.new(wallet.path, log: @log, lock: File.join(@dir, "#{id}.lock")).open(exclusive) do

--- a/lib/zold/tree_wallets.rb
+++ b/lib/zold/tree_wallets.rb
@@ -65,5 +65,9 @@ module Zold
         File.join(path, (id.to_s.split('', 5).take(4) + [id.to_s]).join('/') + Wallet::EXT)
       )
     end
+
+    def count
+      `find . -name "*.z" | wc -l`.strip.to_i
+    end
   end
 end

--- a/lib/zold/wallets.rb
+++ b/lib/zold/wallets.rb
@@ -72,12 +72,10 @@ module Zold
     end
 
     def count
-      begin
-        # Dir.entries returns 2 additional files ('.' and '..')
-        Dir.entries(@dir).count - 2
-      rescue SystemCallError
-        []
-      end
+      # Dir.entries returns 2 additional files ('.' and '..')
+      Dir.entries(@dir).count - 2
+    rescue SystemCallError
+      []
     end
   end
 end

--- a/lib/zold/wallets.rb
+++ b/lib/zold/wallets.rb
@@ -70,5 +70,14 @@ module Zold
       raise "Id must be of type Id, #{id.class.name} instead" unless id.is_a?(Id)
       yield Wallet.new(File.join(path, id.to_s + Wallet::EXT))
     end
+
+    def count
+      begin
+        # Dir.entries returns 2 additional files ('.' and '..')
+        Dir.entries(@dir).count - 2
+      rescue SystemCallError
+        []
+      end
+    end
   end
 end

--- a/lib/zold/wallets.rb
+++ b/lib/zold/wallets.rb
@@ -72,10 +72,7 @@ module Zold
     end
 
     def count
-      # Dir.entries returns 2 additional files ('.' and '..')
-      Dir.entries(@dir).count - 2
-    rescue SystemCallError
-      []
+      Zold::DirItems.new(@dir).fetch(recursive: false).count
     end
   end
 end

--- a/test/test_tree_wallets.rb
+++ b/test/test_tree_wallets.rb
@@ -57,4 +57,17 @@ class TestTreeWallets < Zold::Test
       assert_equal(10, wallets.all.count)
     end
   end
+
+  def test_count_tree_wallets
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        5.times { |i| FileUtils.touch("wallet_#{i}.z") }
+        Dir.mktmpdir(nil, dir) do |subdir|
+          5.times { |i| FileUtils.touch("#{subdir}/wallet_#{i}.z") }
+          wallets = Zold::TreeWallets.new(Dir.pwd)
+          assert_equal(10, wallets.count)
+        end
+      end
+    end
+  end
 end

--- a/test/test_wallets.rb
+++ b/test/test_wallets.rb
@@ -67,4 +67,14 @@ class TestWallets < Zold::Test
       end
     end
   end
+
+  def test_count_wallets
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        5.times { |i| FileUtils.touch("wallet_#{i}") }
+        wallets = Zold::Wallets.new(Dir.pwd)
+        assert_equal(5, wallets.count)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#514 
I added **count** method to _Wallets_ and _TreeWallets_.  _Wallets#count_ performs a tradditional count of any file in its directory while _TreeWallets#count_ traverse through a directory hierarchy and performs a count. 