### PR TITLE
Issue #560 - Fixed problem with test

### DIFF
--- a/test/test_http.rb
+++ b/test/test_http.rb
@@ -123,7 +123,7 @@ class TestHttp < Zold::Test
     RandomPort::Pool::SINGLETON.acquire do |port|
       thread = Thread.start do
         Zold::VerboseThread.new(test_log).run do
-          server = TCPServer.new("127.0.0.1", port)
+          server = TCPServer.new('127.0.0.1', port)
           socket = server.accept
           loop do
             line = socket.gets

--- a/test/test_http.rb
+++ b/test/test_http.rb
@@ -112,11 +112,6 @@ class TestHttp < Zold::Test
     end
   end
 
-  # @todo #444:30min It's obvious that the test works (I can see that in
-  #  the console, but for some weird reason it doesn't work in Minitest. Try
-  #  to run it: ruby test/test_http.rb -n test_sends_correct_http_headers
-  #  If fails because of PUT HTTP request timeout. Let's find the problem,
-  #  fix it, and un-skip the test.
   def test_sends_correct_http_headers
     WebMock.allow_net_connect!
     body = ''

--- a/test/test_http.rb
+++ b/test/test_http.rb
@@ -118,17 +118,16 @@ class TestHttp < Zold::Test
   #  If fails because of PUT HTTP request timeout. Let's find the problem,
   #  fix it, and un-skip the test.
   def test_sends_correct_http_headers
-    skip
     WebMock.allow_net_connect!
     body = ''
     RandomPort::Pool::SINGLETON.acquire do |port|
       thread = Thread.start do
         Zold::VerboseThread.new(test_log).run do
-          server = TCPServer.new(port)
+          server = TCPServer.new("127.0.0.1", port)
           socket = server.accept
           loop do
             line = socket.gets
-            break if line.nil?
+            break if line.eql?("\r\n")
             test_log.info(line.inspect)
             body += line
           end


### PR DESCRIPTION
Issue #560 

I modified the test by breaking the loop when a "\r\n" is returned