### PR TITLE
Issue #618 - New endpoint /wallets

### DIFF
--- a/lib/zold/node/front.rb
+++ b/lib/zold/node/front.rb
@@ -363,6 +363,11 @@ this is not a normal behavior, you may want to report a bug to our GitHub reposi
       )
     end
 
+    get '/wallets' do
+      content_type('text/plain')
+      settings.wallets.all.map(&:to_s).join('\n')
+    end
+
     get '/remotes' do
       content_type('application/json')
       pretty(


### PR DESCRIPTION
Issue #618

I added a new test and code for new endpoint `/wallets`, returning a list of all wallets' id known to the node, separated by `\n`