### PR TITLE
Simple docker container to run zold node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.6
+
+RUN gem install zold
+EXPOSE 4096
+
+RUN mkdir /zold
+WORKDIR /zold
+
+COPY node.sh /
+RUN chmod +x /node.sh
+
+CMD ["/node.sh", "--invoice=17737fee5b825835"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /zold
 COPY node.sh /
 RUN chmod +x /node.sh
 
-CMD ["/node.sh", "--invoice=17737fee5b825835"]
+CMD ["/node.sh", "--host=127.0.0.1", "--invoice=17737fee5b825835"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM ruby:2.6
 RUN gem install zold
 EXPOSE 4096
 
+RUN echo "#!/bin/bash" > node.sh
+RUN echo "zold node --nohup \044\100" >> node.sh
+RUN echo "tail -f zold.log" >> node.sh
+RUN chmod +x /node.sh
+
 RUN mkdir /zold
 WORKDIR /zold
 
-COPY node.sh /
-RUN chmod +x /node.sh
-
-CMD ["/node.sh", "--host=127.0.0.1", "--invoice=17737fee5b825835"]
+CMD ["/node.sh"]

--- a/README.md
+++ b/README.md
@@ -130,14 +130,14 @@ $ zold node --help
 You can run a node in a docker container also.
 
 ```bash
-docker run -d -p 4096:4096 zold/zold:latest /node.sh --invoice=5f96e731e48ae21f
+docker run -d -p 4096:4096 zold/zold:latest /node.sh --host=<your host IP> --invoice=5f96e731e48ae21f
 ```
 
 To store zold data between container restarts create a volume or bind a directory from host
 
 ```bash
 docker volume create zold 
-docker run -d -p 4096:4096 -v zold:/zold zold/zold:latest /node.sh --invoice=5f96e731e48ae21f
+docker run -d -p 4096:4096 -v zold:/zold zold/zold:latest /node.sh --host=<your host IP> --invoice=5f96e731e48ae21f
 ```
 
 ## Frequently Asked Questions

--- a/node.sh
+++ b/node.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-zold node --nohup $@
-tail -f zold.log

--- a/node.sh
+++ b/node.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+zold node --nohup --host=0.0.0.0 $@
+tail -f zold.log

--- a/node.sh
+++ b/node.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-zold node --nohup --host=0.0.0.0 $@
+zold node --nohup $@
 tail -f zold.log


### PR DESCRIPTION
You could create a docker hub image which will be automatically build from dockerfile in this repository. something like zold-io/zold:latest so users could run the node as 

```
docker run -d -p 4096:4096 zold-io/zold:latest /node.sh --host=<your host IP> --invoice=17737fee5b825835
```
Tested on linux and mac only. Should work on Windows too.
