### PR TITLE
Fix #413: keep Hexnum#to_s within the declared width

### DIFF
--- a/lib/zold/hexnum.rb
+++ b/lib/zold/hexnum.rb
@@ -21,7 +21,7 @@ module Zold
     end
 
     def to_s
-      format("%0#{@length}x", @num).gsub(/^\.{2}/, 'ff')
+      format("%0#{@length}x", @num & ((1 << (@length * 4)) - 1))
     end
 
     def self.parse(txt)

--- a/test/test_hexnum.rb
+++ b/test/test_hexnum.rb
@@ -15,4 +15,9 @@ class TestHexnum < Zold::Test
       assert_equal(n, Zold::Hexnum.parse(Zold::Hexnum.new(n, 6).to_s).to_i)
     end
   end
+
+  def test_keeps_width_for_large_negative_amounts
+    text = Zold::Hexnum.new(-((2**52) + 1), 16).to_s
+    assert_equal(16, text.length, "Hexnum#to_s must not produce a string longer than 16 chars, got #{text.inspect}")
+  end
 end


### PR DESCRIPTION
Closes #413.

Hexnum#to_s relied on Ruby's `%x` format collapsing the leading 1-bits of a negative integer into `..f`, then `.gsub(/^\.{2}/, 'ff')` patched the two dots back to two `f`s. That trick only fits 16 hex chars while the magnitude stays within `-(2**52)`; below that the format keeps an extra nibble after `..f` and the result overflows the width, which is why `Txn.parse`'s `[0-9a-f]{16}` group refused to match. Masking the value with `(1 << (@length * 4)) - 1` produces the unsigned low-`@length` nibbles directly, always returns exactly `@length` characters, and round-trips through `Hexnum.parse` for every value the original code handled.

The first commit adds a failing test that pins the width invariant for `-(2**52 + 1)`. The second commit is the one-line fix.