### PR TITLE
render html page at GET / for browsers, keep json for nodes #759

### DIFF
--- a/lib/zold/node/front.rb
+++ b/lib/zold/node/front.rb
@@ -184,8 +184,7 @@ from #{request.ip} in #{Age.new(@start, limit: 1)}")
     end
 
     get '/' do
-      content_type('application/json')
-      pretty(
+      data = {
         repo: Zold::REPO,
         version: settings.opts['expose-version'],
         alias: settings.node_alias,
@@ -227,7 +226,23 @@ this is not a normal behavior, you may want to report a bug to our GitHub reposi
         date: Time.now.utc.iso8601,
         hours_alive: ((Time.now - settings.start) / (60 * 60)).round(2),
         home: 'https://www.zold.io'
-      )
+      }
+      if request.preferred_type('application/json', 'text/html') == 'text/html'
+        content_type('text/html')
+        haml(
+          :home,
+          layout: :layout,
+          locals: data.merge(
+            title: "Zold #{settings.address}",
+            description: "Zold node at #{settings.address}",
+            address: settings.address,
+            node_alias: settings.node_alias
+          )
+        )
+      else
+        content_type('application/json')
+        pretty(data)
+      end
     end
 
     get %r{/wallet/(?<id>[A-Fa-f0-9]{16})} do

--- a/test/node/test_front.rb
+++ b/test/node/test_front.rb
@@ -7,6 +7,7 @@ require 'json'
 require 'time'
 require 'securerandom'
 require 'threads'
+require 'typhoeus'
 require 'zold/score'
 require 'memory_profiler'
 require_relative '../test__helper'
@@ -52,6 +53,26 @@ class FrontTest < Zold::Test
       assert_predicate(json['wallets'], :positive?, json)
       assert_predicate(json['remotes'], :zero?, json)
       assert_predicate(json['nscore'], :zero?, json)
+    end
+  end
+
+  def test_renders_front_html_when_accept_text_html
+    FakeNode.new(log: fake_log).run(opts('--network=foo')) do |port|
+      res = Typhoeus::Request.get(
+        "http://localhost:#{port}/",
+        headers: {
+          'Accept' => 'text/html',
+          Zold::Http::NETWORK_HEADER => 'foo',
+          Zold::Http::PROTOCOL_HEADER => Zold::PROTOCOL.to_s,
+          Zold::Http::VERSION_HEADER => Zold::VERSION
+        },
+        connecttimeout: 0.8,
+        timeout: 2
+      )
+      assert_equal(200, res.code, res.body)
+      assert_match(%r{^text/html}, res.headers['Content-Type'].to_s)
+      assert_match(/This is a Zold node/, res.body)
+      assert_match(/<html/, res.body)
     end
   end
 

--- a/views/home.haml
+++ b/views/home.haml
@@ -1,0 +1,55 @@
+-# SPDX-FileCopyrightText: Copyright (c) 2018-2026 Zerocracy
+-# SPDX-License-Identifier: MIT
+
+%p
+  This is a Zold node.
+  Network:
+  %code= network
+  %br
+  Protocol:
+  %code= protocol
+  %br
+  Version:
+  %code= version
+  %br
+  Alias:
+  %code= node_alias
+  %br
+  Address:
+  %code= address
+
+%table
+  %tbody
+    %tr
+      %th Score
+      %td.right= score[:value]
+    %tr
+      %th Wallets
+      %td.right= wallets
+    %tr
+      %th Remotes
+      %td.right= remotes
+    %tr
+      %th Network score
+      %td.right= nscore
+    %tr
+      %th Threads
+      %td.right= threads
+    %tr
+      %th Hours alive
+      %td.right= hours_alive
+    %tr
+      %th Memory
+      %td.right= Zold::Size.new(memory)
+    %tr
+      %th Date
+      %td.right= date
+
+%p
+  The same data is available as JSON when the
+  %code Accept
+  header asks for
+  %code application/json
+  rather than for
+  %code text/html
+  \.


### PR DESCRIPTION
Resolves #759. The node previously answered `GET /` with the raw JSON status document, which is meant for other zold nodes and is hard to read in a browser. The route now does content negotiation: clients that prefer `text/html` receive a small Haml page that lists the same fields (version, network, protocol, alias, address, score value, wallet count, remotes, threads, hours alive, memory, date), and every other Accept value, including the no-Accept default used by `Zold::Http`, keeps the existing JSON body.

Visible effect: opening `http://0.0.0.0:4096` in a browser now renders the standard layout with a summary table instead of dumping JSON, while `curl http://0.0.0.0:4096` and node-to-node `Zold::Http.new(...).get` calls return the same JSON as before. The new template lives in `views/home.haml` and reuses `views/layout.haml` for the header and navigation.

Checks: `bundle exec rubocop` clean across the 166 files; ruby syntax check passes on both modified files; Haml engine compiles the new template; `Zold::Front` loads with the change applied. A new `test_renders_front_html_when_accept_text_html` asserts the HTML body and Content-Type when Accept is `text/html` and the existing `test_renders_front_json` is untouched. End-to-end test execution against a live `FakeNode` could not run locally because `random-port` falls back to IPv6 sockets in this sandbox; CI on ubuntu-24.04 and macos-15 will exercise the new test.

Closes #759
