### PR TITLE
add --legacy-hours option to zold merge #764

### DIFF
--- a/lib/zold/commands/merge.rb
+++ b/lib/zold/commands/merge.rb
@@ -41,8 +41,11 @@ Available options:"
           'Don\'t propagate after merge',
           default: false
         o.bool '--skip-legacy',
-          'Don\'t make legacy transactions (older than 24 hours) immutable',
+          'Don\'t make legacy transactions immutable',
           default: false
+        o.integer '--legacy-hours',
+          'After how many hours a negative transaction becomes legacy and immutable (default: 24)',
+          default: 24
         o.bool '--quiet-if-absent',
           'Don\'t fail if the wallet is absent',
           default: false
@@ -96,7 +99,7 @@ Available options:"
         @wallets.acq(id) do |w|
           if w.exists?
             s = Time.now
-            patch.legacy(w)
+            patch.legacy(w, hours: opts['legacy-hours'])
             @log.debug("Local copy of #{id} merged legacy in #{Age.new(s)}: #{patch}")
           else
             @log.debug("There is no local copy to merge legacy of #{id}")

--- a/test/test_patch.rb
+++ b/test/test_patch.rb
@@ -157,4 +157,20 @@ class TestPatch < Zold::Test
       end
     end
   end
+
+  def test_legacy_respects_custom_hours
+    FakeHome.new(log: fake_log).run do |home|
+      wallet = home.create_wallet
+      key = Zold::Key.new(file: 'fixtures/id_rsa')
+      target = "NOPREFIX@#{Zold::Id.new}"
+      wallet.sub(Zold::Amount.new(zld: 1.0), target, key, 'old', time: Time.now - (48 * 60 * 60))
+      wallet.sub(Zold::Amount.new(zld: 1.0), target, key, 'fresh', time: Time.now - (1 * 60 * 60))
+      strict = Zold::Patch.new(home.wallets, log: fake_log)
+      strict.legacy(wallet, hours: 6)
+      assert_equal('1 txns', strict.to_s)
+      lax = Zold::Patch.new(home.wallets, log: fake_log)
+      lax.legacy(wallet, hours: 72)
+      assert_equal('nothing', lax.to_s)
+    end
+  end
 end


### PR DESCRIPTION
Issue #764 asked for the legacy interval to be configurable. The hours cutoff passed to `Patch#legacy` was hard-coded to 24 at the call site in `lib/zold/commands/merge.rb`, so operators had no way to tune it from the CLI even though `Patch#legacy` already accepted a keyword.

`zold merge` now exposes `--legacy-hours N`, defaulting to 24, and forwards the value to `Patch#legacy(w, hours: opts['legacy-hours'])`. The wording on `--skip-legacy` no longer hard-codes the 24-hour figure since the threshold is now user-controlled.

Ran `bundle exec ruby -Itest -Ilib test/test_patch.rb`, `test/test_amount.rb`, and `test/commands/test_merge.rb` locally — all green, including the new `test_legacy_respects_custom_hours`. `rubocop lib/zold/commands/merge.rb test/test_patch.rb` reports no offenses on the changed files.

Closes #764