### PR TITLE
Report multiplication overflow correctly

### DIFF
--- a/lib/zold/amount.rb
+++ b/lib/zold/amount.rb
@@ -109,7 +109,7 @@ module Zold
     def *(other)
       raise(RuntimeError, '* may only work with a number') unless other.is_a?(Integer) || other.is_a?(Float)
       c = (@zents * other).truncate
-      raise(RuntimeError, "Overflow, can't multiply #{@zents} by #{m}") if c > MAX
+      raise(RuntimeError, "Overflow, can't multiply #{@zents} by #{other}") if c > MAX
       Amount.new(zents: c)
     end
 

--- a/test/test_amount.rb
+++ b/test/test_amount.rb
@@ -46,6 +46,14 @@ class TestAmount < Zold::Test
     assert_equal(Zold::Amount.new(zld: 2.4), Zold::Amount.new(zld: 1.2) * 2)
   end
 
+  def test_reports_multiplication_overflow
+    error =
+      assert_raises(RuntimeError) do
+        Zold::Amount.new(zents: Zold::Amount::MAX) * 2
+      end
+    assert_equal("Overflow, can't multiply #{Zold::Amount::MAX} by 2", error.message, error.message)
+  end
+
   def test_divides
     assert_equal(Zold::Amount.new(zld: 4.1), Zold::Amount.new(zld: 8.2) / 2)
   end


### PR DESCRIPTION
## Summary

- use the actual multiplier in the multiplication-overflow error message
- add a regression test for the exception class and complete message

The overflow branch previously interpolated an undefined local variable, so Ruby raised `NameError` while constructing the intended `RuntimeError`.

## Verification

- failure-before reproduction confirmed the `NameError`
- focused suite: 8 tests, 21 assertions, no failures or errors
- full RuboCop: 157 files, no offenses
- Yard documentation build, Ruby syntax, and diff checks passed

The full test suite cannot complete locally on Ruby 4.0.5 because the unchanged `zold-score` 0.6.0 native dependency aborts the Ruby process. The same failure reproduces on the untouched base commit; the repository workflow runs the suite with Ruby 3.3.

Fixes #920
